### PR TITLE
fix(react-query) : prefetchQuery 미동작 버그 해결

### DIFF
--- a/src/lib/HTTPClient.ts
+++ b/src/lib/HTTPClient.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const axiosInstance = axios.create({
-  withCredentials: true,
+  baseURL: process.env.SEJULBOOK_BASE_URL,
 });
 
 export const get = async <T>(url: string, params = {}, headers = {}) => {

--- a/src/services/prefetchQuery.ts
+++ b/src/services/prefetchQuery.ts
@@ -4,12 +4,8 @@ import Query from '@/types/query';
 const prefetchQuery = async (queries: Query[]) => {
   const queryClient = new QueryClient();
 
-  const promises = queries.map(async ({ queryKey, queryFn, options }) => {
-    await queryClient.prefetchQuery({
-      queryKey,
-      queryFn: () => queryFn(),
-      ...options,
-    });
+  const promises = queries.map(async ({ queryKey, queryFn }) => {
+    await queryClient.prefetchQuery(queryKey, queryFn);
   });
 
   await Promise.all(promises);


### PR DESCRIPTION
### 작업 내용

(main 브랜치로의 merge 실수로 인해 RePullRequest)

> React Query prefetchQuery 동작 안하는 버그 해결

- axios 인스턴스 생성으로 해결
