### PR TITLE
fix(react-query) : 배포 환경 500 에러 해결 (useQuery 비동기 문제 해결)

### DIFF
--- a/server/database/config.ts
+++ b/server/database/config.ts
@@ -1,10 +1,10 @@
 import { ConnectionOptions } from 'mysql2/promise';
 
 const config: ConnectionOptions = {
-  host: process.env.SEJULBOOK_DB_HOST,
-  user: process.env.SEJULBOOK_DB_USER,
-  database: process.env.SEJULBOOK_DB_DATABASE,
-  password: process.env.SEJULBOOK_DB_PASSWORD,
+  host: process.env.PLANETSCALE_DB_HOST,
+  user: process.env.PLANETSCALE_DB_USERNAME,
+  database: process.env.PLANETSCALE_DB,
+  password: process.env.PLANETSCALE_DB_PASSWORD,
   ssl: { rejectUnauthorized: true },
   connectionLimit: 50,
 };

--- a/server/types/nodejs.d.ts
+++ b/server/types/nodejs.d.ts
@@ -1,9 +1,9 @@
 declare namespace NodeJS {
   export interface ProcessEnv {
-    SEJULBOOK_DB_HOST: string;
-    SEJULBOOK_DB_USER: string;
-    SEJULBOOK_DB_DATABASE: string;
-    SEJULBOOK_DB_PASSWORD: string;
+    PLANETSCALE_DB_HOST: string;
+    PLANETSCALE_DB_USERNAME: string;
+    PLANETSCALE_DB: string;
+    PLANETSCALE_DB_PASSWORD: string;
 
     SEJULBOOK_LOCAL_DB_HOST: string;
     SEJULBOOK_LOCAL_DB_USER: string;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -11,9 +11,10 @@ import globalStyle from '@/styles/global';
 import { LayoutProvider } from '@/contexts/layoutContext';
 import { ScreenModeProvider } from '@/contexts/screenModeContext';
 import { NewbookProvider } from '@/contexts/newbookContext';
+import defaultOptions from '@/services/queries/defaultOptions';
 
 const App = ({ Component, pageProps: { session, ...pageProps } }: AppProps) => {
-  const [queryClient] = useState(() => new QueryClient());
+  const [queryClient] = useState(() => new QueryClient({ defaultOptions }));
 
   return (
     <ScreenModeProvider>

--- a/src/pages/bookreivew/[id].tsx
+++ b/src/pages/bookreivew/[id].tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router';
 import { dehydrate } from '@tanstack/react-query';
 
 import BookReviewTemplate from '@/components/templates/BookReivew';
+import DocumentTitle from '@/components/atoms/DocumentTitle';
 import SejulTextArea from '@/components/organisms/SejulTextarea';
 import ContentEditor from '@/components/organisms/ContentEditor';
 import Rating from '@/components/molecules/Rating';
@@ -40,41 +41,44 @@ const BookreviewPage = () => {
   }
 
   return (
-    <BookReviewTemplate
-      bookReivew={bookReview}
-      likeCommentWidget={
-        <LikeCommentWidget
-          likeCount={bookReview.likeCount}
-          commentCount={comments.length}
-          handleClickLikeButton={() => {}}
-          handleClickCommentButton={handleClickCommentButton}
-        />
-      }
-      sejulViewer={<SejulTextArea value={bookReview.sejul} readonly />}
-      contentViewer={
-        <ContentEditor initialValue={bookReview.content} readonly />
-      }
-      bookInfoButton={
-        <BookInfoBox.Button
-          title={bookReview.bookname}
-          authors={bookReview.authors}
-          thumbnail={bookReview.thumbnail}
-          publisher={bookReview.publisher}
-          datetime={bookReview.publication}
-        >
-          책정보
-        </BookInfoBox.Button>
-      }
-      ratingViewer={
-        <Rating init={Number(bookReview.rating)} size={17} gap={3} readonly />
-      }
-      tagList={tags && <TagList tags={tags} />}
-      comment={
-        <div ref={commentRef}>
-          <CommentContainer comments={comments} />
-        </div>
-      }
-    />
+    <>
+      <DocumentTitle title={bookReview.bookname} />
+      <BookReviewTemplate
+        bookReivew={bookReview}
+        likeCommentWidget={
+          <LikeCommentWidget
+            likeCount={bookReview.likeCount}
+            commentCount={comments.length}
+            handleClickLikeButton={() => {}}
+            handleClickCommentButton={handleClickCommentButton}
+          />
+        }
+        sejulViewer={<SejulTextArea value={bookReview.sejul} readonly />}
+        contentViewer={
+          <ContentEditor initialValue={bookReview.content} readonly />
+        }
+        bookInfoButton={
+          <BookInfoBox.Button
+            title={bookReview.bookname}
+            authors={bookReview.authors}
+            thumbnail={bookReview.thumbnail}
+            publisher={bookReview.publisher}
+            datetime={bookReview.publication}
+          >
+            책정보
+          </BookInfoBox.Button>
+        }
+        ratingViewer={
+          <Rating init={Number(bookReview.rating)} size={17} gap={3} readonly />
+        }
+        tagList={tags && <TagList tags={tags} />}
+        comment={
+          <div ref={commentRef}>
+            <CommentContainer comments={comments} />
+          </div>
+        }
+      />
+    </>
   );
 };
 

--- a/src/services/queries/defaultOptions.ts
+++ b/src/services/queries/defaultOptions.ts
@@ -1,0 +1,9 @@
+import { DefaultOptions } from '@tanstack/react-query';
+
+const defaultOptions: DefaultOptions = {
+  queries: {
+    refetchOnMount: false,
+  },
+};
+
+export default defaultOptions;


### PR DESCRIPTION
### 작업 내용

> prefetch 후 useQuery Hook의 비동기 문제 해결

- React Query `defaultOptions` 내 `refetchOnMount: false`를 추가하여 prefetch 된 쿼리 캐싱 적용
- (기타) Vercel, PlanetScale integration을 위한 환경 변수명 변경
- (기타) bookreveiw page document title 설정
