### PR TITLE
refactor(react-query) : useMutaion Hook 적용

### DIFF
--- a/src/components/organisms/DraftSaveButton/index.tsx
+++ b/src/components/organisms/DraftSaveButton/index.tsx
@@ -1,18 +1,19 @@
 import { useState } from 'react';
+import { useRouter } from 'next/router';
 import Button, { ButtonProps } from '@/components/atoms/Button';
 import { ButtonVariant } from '@/constants';
+import Route from '@/constants/routes';
 import useSavedBookReviewId from '@/hooks/useSavedBookReviewId';
+import useBookReviewDraftSave from '@/hooks/services/mutations/useBookReviewDraftSave';
 import bookReviewStore from '@/stores/bookReviewStore';
 import s3ImageURLStore from '@/stores/s3ImageKeyStore';
-import Route from '@/constants/routes';
 import {
   BookReviewId,
   DraftSavedBookReviewURLQuery,
 } from '@/types/features/bookReview';
-import getInlineURL from '@/utils/getInlineURL';
-import useBookReviewDraftSave from '@/hooks/services/mutations/useBookReviewDraftSave';
 
 const DraftSaveButton = ({ ...buttonProps }: ButtonProps) => {
+  const router = useRouter();
   const { savedBookReviewId, setSavedBookReviewId } = useSavedBookReviewId();
 
   const { bookReview } = bookReviewStore();
@@ -20,7 +21,7 @@ const DraftSaveButton = ({ ...buttonProps }: ButtonProps) => {
 
   const [isPossibleSave, setIsPossibleSave] = useState(true);
 
-  const chageURL = (bookReviewId: BookReviewId) => {
+  const replaceURL = (bookReviewId: BookReviewId) => {
     if (savedBookReviewId) {
       return;
     }
@@ -28,14 +29,16 @@ const DraftSaveButton = ({ ...buttonProps }: ButtonProps) => {
     const query: DraftSavedBookReviewURLQuery = {
       draft: bookReviewId,
     };
-    const url = getInlineURL({ baseURL: Route.NEWBOOK_WRITE, query });
 
-    window.history.replaceState(null, '', url);
+    router.replace({
+      pathname: Route.NEWBOOK_WRITE,
+      query,
+    });
   };
 
   const handleSuccess = (bookReviewId: BookReviewId) => {
     emptyImageKeySet();
-    chageURL(bookReviewId);
+    replaceURL(bookReviewId);
     setSavedBookReviewId(bookReviewId);
     setIsPossibleSave(true);
   };

--- a/src/components/organisms/DraftSavedListModal/index.tsx
+++ b/src/components/organisms/DraftSavedListModal/index.tsx
@@ -1,17 +1,13 @@
 import Link from 'next/link';
-import { toast } from 'react-toastify';
 import Button, { ButtonProps } from '@/components/atoms/Button';
 import { DeleteIcon } from '@/components/atoms/Icon';
 import Modal, { ModalProps } from '@/components/molecules/Modal';
 import { ButtonVariant, ColorVariant } from '@/constants';
 import { ModalKey } from '@/constants/keys';
-import { userError } from '@/constants/message';
 import Route from '@/constants/routes';
-import useUserStatus from '@/hooks/useUserStatus';
 import modalStore from '@/stores/modalStore';
 import formatDateToKorean from '@/utils/formatDateToKorean';
-import { deleteBookReview } from '@/services/api/bookReview';
-import { BookReviewError } from '@/services/errors/BookReviewError';
+import useDraftSavedDeletion from '@/hooks/services/mutations/useDraftSavedDeletion';
 import {
   DraftSavedBookReview,
   DraftSavedBookReviewURLQuery,
@@ -24,29 +20,19 @@ interface DraftSavedListModalProps
 }
 
 const DraftSavedItem = ({ id, bookname, createdAt }: DraftSavedBookReview) => {
-  const { session, isLogin } = useUserStatus();
   const { closeModal } = modalStore();
+
+  const deleteDraftSavedBookReview = useDraftSavedDeletion({
+    bookReviewId: id,
+  });
 
   const draftSavedURLQuery: DraftSavedBookReviewURLQuery = {
     draft: id,
   };
 
-  const handleClickDeleteButton = async () => {
-    if (!isLogin) {
-      toast.error(userError.NOT_LOGGED);
-      return;
-    }
-
-    if (!window.confirm('임시저장 독후감을 정말 삭제하시겠습니까?')) {
-      return;
-    }
-
-    try {
-      await deleteBookReview({ userId: session.id, bookReviewId: id });
-    } catch (error) {
-      if (error instanceof BookReviewError) {
-        toast.error(error.message);
-      }
+  const handleClickDeleteButton = () => {
+    if (window.confirm('임시저장 독후감을 정말 삭제하시겠습니까?')) {
+      deleteDraftSavedBookReview();
     }
   };
 

--- a/src/hooks/services/mutations/useBookReviewDraftSave.ts
+++ b/src/hooks/services/mutations/useBookReviewDraftSave.ts
@@ -1,0 +1,72 @@
+import { toast } from 'react-toastify';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import useUserStatus from '@/hooks/useUserStatus';
+import { bookReviewSussess, userError } from '@/constants/message';
+import { draftSaveBookReview } from '@/services/api/bookReview';
+import { BookReviewError } from '@/services/errors/BookReviewError';
+import { UserId } from '@/types/features/user';
+import { BookReviewId, NewBookReview } from '@/types/features/bookReview';
+import { getBookReviewQuery } from '@/services/queries/bookReview';
+
+interface BookReviewDraftSaveProps {
+  bookReview: NewBookReview;
+  savedBookReviewId?: UserId;
+  onSuccess?: (bookReviewId: BookReviewId) => void;
+  onError?: () => void;
+}
+
+const useBookReviewDraftSave = ({
+  bookReview,
+  savedBookReviewId,
+  onSuccess,
+  onError,
+}: BookReviewDraftSaveProps) => {
+  const queryClient = useQueryClient();
+  const { session, isLogin } = useUserStatus();
+
+  const mutationFn = async () => {
+    if (!isLogin) {
+      toast.error(userError.NOT_LOGGED);
+      return null;
+    }
+
+    const bookReviewId = await draftSaveBookReview({
+      userId: session.id,
+      bookReviewId: savedBookReviewId,
+      bookReview,
+    });
+
+    return bookReviewId;
+  };
+
+  const { mutate } = useMutation({
+    mutationFn,
+    onSuccess: (bookReviewId) => {
+      toast.success(bookReviewSussess.DRAFT_SAVE);
+
+      if (!bookReviewId) {
+        return;
+      }
+
+      queryClient.invalidateQueries(getBookReviewQuery(bookReviewId).queryKey);
+
+      if (onSuccess) {
+        onSuccess(bookReviewId);
+      }
+    },
+    onError: (error) => {
+      if (error instanceof BookReviewError) {
+        toast.error(error.message);
+      }
+
+      if (onError) {
+        onError();
+      }
+    },
+  });
+
+  return mutate;
+};
+
+export default useBookReviewDraftSave;

--- a/src/hooks/services/mutations/useBookReviewPublication.ts
+++ b/src/hooks/services/mutations/useBookReviewPublication.ts
@@ -1,9 +1,9 @@
-import { useState } from 'react';
 import { toast } from 'react-toastify';
 import { useMutation } from '@tanstack/react-query';
 
 import { publishBookReview } from '@/services/api/bookReview';
 import { BookReviewError } from '@/services/errors/BookReviewError';
+
 import useUserStatus from '@/hooks/useUserStatus';
 import { userError } from '@/constants/message';
 import { BookReviewId, NewBookReview } from '@/types/features/bookReview';
@@ -12,27 +12,22 @@ interface BookReviewPublicationProps {
   bookReview: NewBookReview;
   savedBookReviewId?: BookReviewId;
   onSuccess?: (bookReviewId: BookReviewId) => void;
+  onError?: () => void;
 }
 
 const useBookReviewPublication = ({
   bookReview,
   savedBookReviewId,
   onSuccess,
+  onError,
 }: BookReviewPublicationProps) => {
   const { session, isLogin } = useUserStatus();
-  const [isPossiblePublish, setIsPossiblePublish] = useState(true);
 
   const mutationFn = async () => {
-    if (!isPossiblePublish) {
-      return null;
-    }
-
     if (!isLogin) {
       toast.error(userError.NOT_LOGGED);
       return null;
     }
-
-    setIsPossiblePublish(false);
 
     const bookReviewId = await publishBookReview({
       userId: session.id,
@@ -46,15 +41,16 @@ const useBookReviewPublication = ({
   const { mutate } = useMutation({
     mutationFn,
     onSuccess: (data) => {
-      setIsPossiblePublish(true);
       if (onSuccess && data) {
         onSuccess(data);
       }
     },
     onError: (error) => {
-      setIsPossiblePublish(true);
       if (error instanceof BookReviewError) {
         toast.error(error.message);
+      }
+      if (onError) {
+        onError();
       }
     },
   });

--- a/src/hooks/services/mutations/useBookReviewPublication.ts
+++ b/src/hooks/services/mutations/useBookReviewPublication.ts
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import { toast } from 'react-toastify';
+import { useMutation } from '@tanstack/react-query';
+
+import { publishBookReview } from '@/services/api/bookReview';
+import { BookReviewError } from '@/services/errors/BookReviewError';
+import useUserStatus from '@/hooks/useUserStatus';
+import { userError } from '@/constants/message';
+import { BookReviewId, NewBookReview } from '@/types/features/bookReview';
+
+interface BookReviewPublicationProps {
+  bookReview: NewBookReview;
+  savedBookReviewId?: BookReviewId;
+  onSuccess?: (bookReviewId: BookReviewId) => void;
+}
+
+const useBookReviewPublication = ({
+  bookReview,
+  savedBookReviewId,
+  onSuccess,
+}: BookReviewPublicationProps) => {
+  const { session, isLogin } = useUserStatus();
+  const [isPossiblePublish, setIsPossiblePublish] = useState(true);
+
+  const mutationFn = async () => {
+    if (!isPossiblePublish) {
+      return null;
+    }
+
+    if (!isLogin) {
+      toast.error(userError.NOT_LOGGED);
+      return null;
+    }
+
+    setIsPossiblePublish(false);
+
+    const bookReviewId = await publishBookReview({
+      userId: session.id,
+      bookReviewId: savedBookReviewId,
+      bookReview,
+    });
+
+    return bookReviewId;
+  };
+
+  const { mutate } = useMutation({
+    mutationFn,
+    onSuccess: (data) => {
+      setIsPossiblePublish(true);
+      if (onSuccess && data) {
+        onSuccess(data);
+      }
+    },
+    onError: (error) => {
+      setIsPossiblePublish(true);
+      if (error instanceof BookReviewError) {
+        toast.error(error.message);
+      }
+    },
+  });
+
+  return mutate;
+};
+
+export default useBookReviewPublication;

--- a/src/hooks/services/mutations/useDraftSavedDeletion.ts
+++ b/src/hooks/services/mutations/useDraftSavedDeletion.ts
@@ -1,0 +1,46 @@
+import { toast } from 'react-toastify';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import useUserStatus from '@/hooks/useUserStatus';
+import { userError } from '@/constants/message';
+import { deleteBookReview } from '@/services/api/bookReview';
+import { BookReviewError } from '@/services/errors/BookReviewError';
+import { BookReviewId } from '@/types/features/bookReview';
+import { getDraftSavedListQuery } from '@/services/queries/bookReview';
+
+interface DraftSavedBookReviewDeletionProps {
+  bookReviewId: BookReviewId;
+}
+
+const useDraftSavedDeletion = ({
+  bookReviewId,
+}: DraftSavedBookReviewDeletionProps) => {
+  const queryClient = useQueryClient();
+  const { session, isLogin } = useUserStatus();
+
+  const mutationFn = async () => {
+    if (!isLogin) {
+      toast.error(userError.NOT_LOGGED);
+      return;
+    }
+
+    await deleteBookReview({ userId: session.id, bookReviewId });
+  };
+
+  const { mutate } = useMutation({
+    mutationFn,
+    onSuccess: () => {
+      if (isLogin) {
+        queryClient.invalidateQueries(getDraftSavedListQuery(session.id));
+      }
+    },
+    onError: (error) => {
+      if (error instanceof BookReviewError) {
+        toast.error(error.message);
+      }
+    },
+  });
+
+  return mutate;
+};
+
+export default useDraftSavedDeletion;

--- a/src/hooks/useHiddenLayout.ts
+++ b/src/hooks/useHiddenLayout.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { useLayoutContext } from '@/contexts/layoutContext';
 
-const useLayoutVisibility = (isHide = true) => {
+const useHiddenLayout = () => {
   const {
     showHeaderBar,
     hideHeaderBar,
@@ -10,10 +10,8 @@ const useLayoutVisibility = (isHide = true) => {
   } = useLayoutContext();
 
   useEffect(() => {
-    if (isHide) {
-      hideHeaderBar();
-      hideScreenModeButton();
-    }
+    hideHeaderBar();
+    hideScreenModeButton();
 
     return () => {
       showHeaderBar();
@@ -22,10 +20,9 @@ const useLayoutVisibility = (isHide = true) => {
   }, [
     hideHeaderBar,
     hideScreenModeButton,
-    isHide,
     showHeaderBar,
     showScreenModeButton,
   ]);
 };
 
-export default useLayoutVisibility;
+export default useHiddenLayout;

--- a/src/hooks/useNewbookFetch.ts
+++ b/src/hooks/useNewbookFetch.ts
@@ -2,16 +2,11 @@ import { useEffect } from 'react';
 import { useNewbookContext } from '@/contexts/newbookContext';
 import bookReviewStore from '@/stores/bookReviewStore';
 import { BookReviewId } from '@/types/features/bookReview';
-import useLayoutVisibility from './useLayoutVisibility';
-import useSavedBookReviewInitialization from './useSavedBookReviewInitialization';
 
-const useNewbookWriteInitialization = (savedBookReviewId?: BookReviewId) => {
+const useNewbookFetch = (savedBookReviewId?: BookReviewId) => {
   const { getNewbook } = useNewbookContext();
-  const { newBook, isLoading: isNewBookLoading } = getNewbook();
-
+  const { newBook, isLoading } = getNewbook();
   const { bookReview, setBook, setThumbnail } = bookReviewStore();
-
-  const { isLoading } = useSavedBookReviewInitialization(savedBookReviewId);
 
   useEffect(() => {
     if (savedBookReviewId) {
@@ -30,9 +25,7 @@ const useNewbookWriteInitialization = (savedBookReviewId?: BookReviewId) => {
     setThumbnail,
   ]);
 
-  useLayoutVisibility(Boolean(bookReview.book.title));
-
-  return { bookReview, isLoading: isLoading || isNewBookLoading };
+  return { newBook, isLoading };
 };
 
-export default useNewbookWriteInitialization;
+export default useNewbookFetch;

--- a/src/hooks/useSavedBookReviewFetch.ts
+++ b/src/hooks/useSavedBookReviewFetch.ts
@@ -38,10 +38,6 @@ const useSavedBookReviewFetch = (bookReviewId: BookReviewId | undefined) => {
         thumbnail: undefined,
       });
     }
-
-    return () => {
-      initBookReview();
-    };
   }, [initBookReview, savedBookReview, setBookReivew, setNewbook, tags]);
 
   useEffect(() => {

--- a/src/hooks/useSavedBookReviewFetch.ts
+++ b/src/hooks/useSavedBookReviewFetch.ts
@@ -6,9 +6,7 @@ import { BookReviewId } from '@/types/features/bookReview';
 import useBookReview from './services/queries/useBookReview';
 import useTags from './services/queries/useTags';
 
-const useSavedBookReviewInitialization = (
-  bookReviewId: BookReviewId | undefined,
-) => {
+const useSavedBookReviewFetch = (bookReviewId: BookReviewId | undefined) => {
   const [isLoading, setIsLoading] = useState(!!bookReviewId);
   const savedBookReview = useBookReview(bookReviewId);
   const tags = useTags(bookReviewId);
@@ -55,4 +53,4 @@ const useSavedBookReviewInitialization = (
   return { isLoading };
 };
 
-export default useSavedBookReviewInitialization;
+export default useSavedBookReviewFetch;

--- a/src/pages/newbook/write.tsx
+++ b/src/pages/newbook/write.tsx
@@ -38,7 +38,7 @@ const NewbookWritePage = ({
           bookName={book.title ? book.title : undefined}
           sejulTextarea={<SejulTextArea />}
           contentTextarea={<ContentEditor />}
-          publishButton={book && <PublishSideBar.Button newbook={book} />}
+          publishButton={book && <PublishSideBar.Button />}
           draftSaveButton={book && <DraftSaveButton />}
         />
       )}

--- a/src/pages/newbook/write.tsx
+++ b/src/pages/newbook/write.tsx
@@ -9,7 +9,7 @@ import PublishSideBar from '@/components/organisms/PublishSideBar';
 import DraftSaveButton from '@/components/organisms/DraftSaveButton';
 
 import useS3GarbageCollection from '@/hooks/useS3GarbageCollection';
-import useNewbookWriteInitialization from '@/hooks/useNewbookWriteInitialization';
+import useNewbookFetch from '@/hooks/useNewbookFetch';
 import { BookReviewId } from '@/types/features/bookReview';
 import checkLogin, { checkRedirect } from '@/services/middlewares/checkLogin';
 import prefetchQuery from '@/services/prefetchQuery';
@@ -17,17 +17,23 @@ import {
   getBookReviewQuery,
   getTagsQuery,
 } from '@/services/queries/bookReview';
+import useSavedBookReviewFetch from '@/hooks/useSavedBookReviewFetch';
+import useHiddenLayout from '@/hooks/useHiddenLayout';
 
 const NewbookWritePage = ({
   savedBookReviewId,
 }: {
   savedBookReviewId?: BookReviewId;
 }) => {
-  const {
-    bookReview: { book },
-    isLoading,
-  } = useNewbookWriteInitialization(savedBookReviewId);
+  const { newBook, isLoading: newBookLoading } =
+    useNewbookFetch(savedBookReviewId);
 
+  const { isLoading: savedBookReviewLoading } =
+    useSavedBookReviewFetch(savedBookReviewId);
+
+  const isLoading = newBookLoading || savedBookReviewLoading;
+
+  useHiddenLayout();
   useS3GarbageCollection();
 
   return (
@@ -35,11 +41,11 @@ const NewbookWritePage = ({
       <DocumentTitle title="독후감 쓰기" />
       {!isLoading && (
         <NewbookWrite
-          bookName={book.title ? book.title : undefined}
+          bookName={newBook ? newBook.title : undefined}
           sejulTextarea={<SejulTextArea />}
           contentTextarea={<ContentEditor />}
-          publishButton={book && <PublishSideBar.Button />}
-          draftSaveButton={book && <DraftSaveButton />}
+          publishButton={newBook && <PublishSideBar.Button />}
+          draftSaveButton={newBook && <DraftSaveButton />}
         />
       )}
     </>


### PR DESCRIPTION
### 작업 내용

> React Query `useMutaion` Hook을 적용하여 쿼리 캐시가 refetch되도록 한다.

- 독후감 발행 mutation Hook 구현
- 독후감 임시저장 mutation Hook 구현
- 임시저장 독후감 삭제 mutation Hook 구현
