### PR TITLE
fix(react-query) : React Query useMutation Hook 로딩시 사용불가 적용

### DIFF
--- a/src/components/organisms/CommentContainer/index.tsx
+++ b/src/components/organisms/CommentContainer/index.tsx
@@ -27,6 +27,12 @@ const CommentContainer = ({
   const addComment = useCommentCreation({
     bookReviewId,
     content: writingContent,
+    onSuccess: () => {
+      window.scrollTo({
+        top: document.body.scrollHeight,
+        behavior: 'smooth',
+      });
+    },
   });
 
   const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {

--- a/src/components/organisms/DraftSaveButton/index.tsx
+++ b/src/components/organisms/DraftSaveButton/index.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { useRouter } from 'next/router';
 import Button, { ButtonProps } from '@/components/atoms/Button';
 import { ButtonVariant } from '@/constants';
@@ -18,8 +17,6 @@ const DraftSaveButton = ({ ...buttonProps }: ButtonProps) => {
 
   const { bookReview } = bookReviewStore();
   const { emptyImageKeySet } = s3ImageURLStore();
-
-  const [isPossibleSave, setIsPossibleSave] = useState(true);
 
   const replaceURL = (bookReviewId: BookReviewId) => {
     if (savedBookReviewId) {
@@ -46,21 +43,12 @@ const DraftSaveButton = ({ ...buttonProps }: ButtonProps) => {
     bookReview,
     savedBookReviewId,
     onSuccess: handleSuccess,
-    onFinish: () => setIsPossibleSave(true),
   });
-
-  const handleClick = async () => {
-    if (!isPossibleSave) {
-      return;
-    }
-    setIsPossibleSave(false);
-    draftSaveBookReview();
-  };
 
   return (
     <Button
       variant={ButtonVariant.OUTLINED}
-      onClick={handleClick}
+      onClick={() => draftSaveBookReview()}
       {...buttonProps}
     >
       임시저장

--- a/src/components/organisms/PublishSideBar/index.tsx
+++ b/src/components/organisms/PublishSideBar/index.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { useRouter } from 'next/router';
 
 import { ButtonVariant, ColorVariant } from '@/constants';
@@ -36,7 +35,6 @@ const PublishSideBar = ({
 }: PublishSideBarProps) => {
   const router = useRouter();
   const { savedBookReviewId } = useSavedBookReviewId();
-  const [isPossiblePublish, setIsPossiblePublish] = useState(true);
 
   const { deleteImageKey } = s3ImageURLStore();
   const { bookReview, setCategory, setRating, setTag } = bookReviewStore();
@@ -57,16 +55,7 @@ const PublishSideBar = ({
     bookReview,
     savedBookReviewId,
     onSuccess: handleSuccess,
-    onFinish: () => setIsPossiblePublish(true),
   });
-
-  const handlePublish = () => {
-    if (!isPossiblePublish) {
-      return;
-    }
-    setIsPossiblePublish(false);
-    publishBookReview();
-  };
 
   return (
     <SideBar anchorEl={anchorEl} handleClose={handleClose}>
@@ -103,7 +92,7 @@ const PublishSideBar = ({
           <Button
             variant={ButtonVariant.OUTLINED}
             color={ColorVariant.PRIMARY}
-            onClick={handlePublish}
+            onClick={() => publishBookReview()}
           >
             발행
           </Button>

--- a/src/hooks/services/mutations/useCommentDeletion.ts
+++ b/src/hooks/services/mutations/useCommentDeletion.ts
@@ -1,34 +1,25 @@
 import { toast } from 'react-toastify';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQueryClient } from '@tanstack/react-query';
 import { CommentDeleteRequest } from '@/types/features/comment';
 import { getCommentsQuery } from '@/services/queries/comment';
 import CommentError from '@/services/errors/CommentError';
 import { deleteComment } from '@/services/api/comment';
-import useUserStatus from '@/hooks/useUserStatus';
-import { userError } from '@/constants/message';
+import useMutation from '@/hooks/useMutation';
 
 const useCommentDeletion = ({
   bookReviewId,
 }: Pick<CommentDeleteRequest, 'bookReviewId'>) => {
-  const { session, isLogin } = useUserStatus();
   const queryClient = useQueryClient();
 
-  const mutationFn = async ({ id }: Pick<CommentDeleteRequest, 'id'>) => {
-    if (!isLogin) {
-      toast.error(userError.NOT_LOGGED);
-      return false;
-    }
-    await deleteComment({ id, bookReviewId, userId: session.id });
-    return true;
-  };
-
-  const { mutate } = useMutation({
-    mutationFn,
-    onSuccess: (isSuccess) => {
-      if (isSuccess) {
-        queryClient.invalidateQueries(getCommentsQuery(bookReviewId));
-      }
+  const { mutate } = useMutation<void, Pick<CommentDeleteRequest, 'id'>>({
+    mutationFn: async (userId, { id }) => {
+      await deleteComment({ id, bookReviewId, userId });
     },
+
+    onSuccess: () => {
+      queryClient.invalidateQueries(getCommentsQuery(bookReviewId));
+    },
+
     onError: (error) => {
       if (error instanceof CommentError) {
         toast.error(error.message);

--- a/src/hooks/services/mutations/useCommentEdit.ts
+++ b/src/hooks/services/mutations/useCommentEdit.ts
@@ -1,44 +1,33 @@
 import { toast } from 'react-toastify';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import useUserStatus from '@/hooks/useUserStatus';
+import { useQueryClient } from '@tanstack/react-query';
+import useMutation from '@/hooks/useMutation';
 import { CommentUpdateRequest } from '@/types/features/comment';
-import { userError } from '@/constants/message';
 import { updateComment } from '@/services/api/comment';
 import { getCommentsQuery } from '@/services/queries/comment';
 import CommentError from '@/services/errors/CommentError';
+
+type MutationArgType = Pick<CommentUpdateRequest, 'id' | 'content'>;
 
 const useCommentEdit = ({
   bookReviewId,
 }: Pick<CommentUpdateRequest, 'bookReviewId'>) => {
   const queryClient = useQueryClient();
-  const { session, isLogin } = useUserStatus();
 
-  const mutationFn = async ({
-    id,
-    content,
-  }: Pick<CommentUpdateRequest, 'id' | 'content'>) => {
-    if (!isLogin) {
-      toast.error(userError.NOT_LOGGED);
-      return false;
-    }
-
-    await updateComment({
-      id,
-      content,
-      bookReviewId,
-      userId: session.id,
-    });
-
-    return true;
-  };
-
-  const { mutate } = useMutation({
-    mutationFn,
-    onSuccess: (isSuccess) => {
-      if (isSuccess) {
-        queryClient.invalidateQueries(getCommentsQuery(bookReviewId));
-      }
+  const { mutate } = useMutation<void, MutationArgType>({
+    mutationFn: async (userId, { id, content }) => {
+      await updateComment({
+        id,
+        content,
+        bookReviewId,
+        userId,
+      });
     },
+
+    onSuccess: () => {
+      const queryKey = getCommentsQuery(bookReviewId);
+      queryClient.invalidateQueries(queryKey);
+    },
+
     onError: (error) => {
       if (error instanceof CommentError) {
         toast.error(error.message);

--- a/src/hooks/services/mutations/useLikeToggle.ts
+++ b/src/hooks/services/mutations/useLikeToggle.ts
@@ -1,9 +1,8 @@
 import { useState } from 'react';
 import { toast } from 'react-toastify';
-import { QueryKey, useMutation, useQueryClient } from '@tanstack/react-query';
+import { QueryKey, useQueryClient } from '@tanstack/react-query';
 import { LikeRequest, LikeResponse } from '@/types/features/like';
-import useUserStatus from '@/hooks/useUserStatus';
-import { userError } from '@/constants/message';
+import useMutation from '@/hooks/useMutation';
 import { like, unlike } from '@/services/api/like';
 import { BookReviewError } from '@/services/errors/BookReviewError';
 import { getLikeStatusQuery } from '@/services/queries/like';
@@ -12,35 +11,24 @@ type LikeToggleProps = LikeRequest & Pick<LikeResponse, 'isLike'>;
 
 const useLikeToggle = ({ isLike, bookReviewId }: LikeToggleProps) => {
   const queryClient = useQueryClient();
-  const { session, isLogin } = useUserStatus();
   const [queryKey, setQueryKey] = useState<QueryKey>();
 
-  const mutationFn = async () => {
-    if (!isLogin) {
-      toast.error(userError.NOT_LOGGED);
-      return false;
-    }
-
-    setQueryKey(
-      getLikeStatusQuery({ userId: session.id, bookReviewId }).queryKey,
-    );
-
-    if (isLike) {
-      await unlike({ userId: session.id, bookReviewId });
-      return true;
-    }
-
-    await like({ userId: session.id, bookReviewId });
-    return true;
-  };
-
   const { mutate } = useMutation({
-    mutationFn,
-    onSuccess: (isSuccess) => {
-      if (isSuccess) {
-        queryClient.invalidateQueries(queryKey);
+    mutationFn: async (userId) => {
+      setQueryKey(getLikeStatusQuery({ userId, bookReviewId }).queryKey);
+
+      if (isLike) {
+        await unlike({ userId, bookReviewId });
+        return;
       }
+
+      await like({ userId, bookReviewId });
     },
+
+    onSuccess: () => {
+      queryClient.invalidateQueries(queryKey);
+    },
+
     onError: (error) => {
       if (error instanceof BookReviewError) {
         toast.error(error.message);

--- a/src/hooks/services/mutations/useUserEdit.ts
+++ b/src/hooks/services/mutations/useUserEdit.ts
@@ -1,39 +1,30 @@
 import { toast } from 'react-toastify';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import useUserStatus from '@/hooks/useUserStatus';
-import { userError } from '@/constants/message';
+import { QueryKey, useQueryClient } from '@tanstack/react-query';
+import useMutation from '@/hooks/useMutation';
 import { updateUser } from '@/services/api/user';
 import { User } from '@/types/features/user';
 import { getUserQuery } from '@/services/queries/user';
 import UserError from '@/services/errors/UserError';
+import { useState } from 'react';
 
 const useUserEdit = ({ onSuccess }: { onSuccess?: () => void } = {}) => {
   const queryClient = useQueryClient();
-  const { session, isLogin } = useUserStatus();
+  const [queryKey, setQueryKey] = useState<QueryKey>([]);
 
-  const mutationFn = async ({ name, introduce }: Omit<User, 'id'>) => {
-    if (!isLogin) {
-      toast.error(userError.NOT_LOGGED);
-      return false;
-    }
+  const { mutate } = useMutation<void, Omit<User, 'id'>>({
+    mutationFn: async (userId, { name, introduce }) => {
+      setQueryKey(getUserQuery(userId).queryKey);
+      await updateUser({ id: userId, name, introduce });
+    },
 
-    await updateUser({ id: session.id, name, introduce });
-    return true;
-  };
+    onSuccess: () => {
+      queryClient.invalidateQueries(queryKey);
 
-  const { mutate } = useMutation({
-    mutationFn,
-    onSuccess: (isSuccess) => {
-      if (!isSuccess) {
-        return;
-      }
-      if (isLogin) {
-        queryClient.invalidateQueries(getUserQuery(session.id));
-      }
       if (onSuccess) {
         onSuccess();
       }
     },
+
     onError: (error) => {
       if (error instanceof UserError) {
         toast.error(error.message);

--- a/src/hooks/useMutation.ts
+++ b/src/hooks/useMutation.ts
@@ -11,23 +11,23 @@ class MutationFail {
   fail = true;
 }
 
-interface MutationProps<T> {
-  mutationFn: (userId: UserId) => Promise<T>;
+interface MutationProps<T, U> {
+  mutationFn: (userId: UserId, args: U) => Promise<T>;
   onSuccess: (data: T) => void;
   onError: (error: unknown) => void;
   queryKeysToRefetch?: QueryKey[];
 }
 
-const useMutation = <T>({
+const useMutation = <T, U = void>({
   mutationFn,
   onSuccess,
   onError,
-}: MutationProps<T>) => {
+}: MutationProps<T, U>) => {
   const mutationFail = new MutationFail();
   const { session, isLogin } = useUserStatus();
 
   const mutationResult = useOriginMutation({
-    mutationFn: async () => {
+    mutationFn: async (args: U) => {
       if (mutationResult.isLoading) {
         return mutationFail;
       }
@@ -37,7 +37,7 @@ const useMutation = <T>({
         return mutationFail;
       }
 
-      return mutationFn(session.id);
+      return mutationFn(session.id, args);
     },
 
     onSuccess: (data) => {

--- a/src/hooks/useMutation.ts
+++ b/src/hooks/useMutation.ts
@@ -1,0 +1,63 @@
+import { toast } from 'react-toastify';
+import {
+  QueryKey,
+  useMutation as useOriginMutation,
+} from '@tanstack/react-query';
+import { userError } from '@/constants/message';
+import { UserId } from '@/types/features/user';
+import useUserStatus from './useUserStatus';
+
+class MutationFail {
+  fail = true;
+}
+
+interface MutationProps<T> {
+  mutationFn: (userId: UserId) => Promise<T>;
+  onSuccess: (data: T) => void;
+  onError: (error: unknown) => void;
+  queryKeysToRefetch?: QueryKey[];
+}
+
+const useMutation = <T>({
+  mutationFn,
+  onSuccess,
+  onError,
+}: MutationProps<T>) => {
+  const mutationFail = new MutationFail();
+  const { session, isLogin } = useUserStatus();
+
+  const mutationResult = useOriginMutation({
+    mutationFn: async () => {
+      if (mutationResult.isLoading) {
+        return mutationFail;
+      }
+
+      if (!isLogin) {
+        toast.error(userError.NOT_LOGGED);
+        return mutationFail;
+      }
+
+      return mutationFn(session.id);
+    },
+
+    onSuccess: (data) => {
+      if (data instanceof MutationFail) {
+        return;
+      }
+
+      if (onSuccess) {
+        onSuccess(data);
+      }
+    },
+
+    onError: (error) => {
+      if (onError) {
+        onError(error);
+      }
+    },
+  });
+
+  return mutationResult;
+};
+
+export default useMutation;

--- a/src/hooks/useMutation.ts
+++ b/src/hooks/useMutation.ts
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { toast } from 'react-toastify';
 import {
   QueryKey,
@@ -24,13 +25,16 @@ const useMutation = <T, U = void>({
   onError,
 }: MutationProps<T, U>) => {
   const mutationFail = new MutationFail();
+  const [isLoading, setIsLoading] = useState(false);
   const { session, isLogin } = useUserStatus();
 
   const mutationResult = useOriginMutation({
     mutationFn: async (args: U) => {
-      if (mutationResult.isLoading) {
+      if (mutationResult.isLoading || isLoading) {
         return mutationFail;
       }
+
+      setIsLoading(true);
 
       if (!isLogin) {
         toast.error(userError.NOT_LOGGED);
@@ -41,6 +45,10 @@ const useMutation = <T, U = void>({
     },
 
     onSuccess: (data) => {
+      setTimeout(() => {
+        setIsLoading(false);
+      }, 1000);
+
       if (data instanceof MutationFail) {
         return;
       }
@@ -51,6 +59,8 @@ const useMutation = <T, U = void>({
     },
 
     onError: (error) => {
+      setIsLoading(false);
+
       if (onError) {
         onError(error);
       }


### PR DESCRIPTION
### 작업 내용

> 독후감 발행, 임시저장, 좋아요 기능 반복(ex. 버튼 연타)시 발생하는 버그 해결

- `useMutation` 커스텀 Hook 구현
- `mutaionFn` 반복 실행(=연타) 방지 적용
