### PR TITLE
fix(accessibility) : Chrome 외 환경에서의 아이콘 버튼 내 텍스트 숨김 미동작 해결

### DIFF
--- a/src/components/atoms/Button/index.tsx
+++ b/src/components/atoms/Button/index.tsx
@@ -4,6 +4,7 @@ import { ColorVariant, ButtonVariant } from '@/constants';
 import { StyleProps } from '@/types/style';
 import { useScreenModeContext } from '@/contexts/screenModeContext';
 import getColorByColorVariant from '@/utils/getColorByColorVariant';
+import { iconButtonStyle } from '@/styles/common';
 import * as s from './style';
 
 type ButtonAttributes = {
@@ -48,7 +49,8 @@ const CancelButton = ({
 }: {
   size?: string | number;
 } & ButtonProps) => (
-  <Button {...buttonProps}>
+  <Button {...buttonProps} css={iconButtonStyle}>
+    취소
     <HiX size={size} />
   </Button>
 );

--- a/src/components/molecules/EditDeleteButtonSet/index.tsx
+++ b/src/components/molecules/EditDeleteButtonSet/index.tsx
@@ -1,10 +1,14 @@
 import styled from '@emotion/styled';
 import Button from '@/components/atoms/Button';
 import { EditIcon, DeleteIcon } from '@/components/atoms/Icon';
+import { iconButtonStyle } from '@/styles/common';
 
 const ButtonWrapper = styled.div`
   display: flex;
   gap: 10px;
+  button {
+    ${iconButtonStyle}
+  }
 `;
 
 interface EditDeleteButtonSetProps {
@@ -25,6 +29,7 @@ export const EditButton = ({
 >) =>
   isShowEditButton ? (
     <Button onClick={onClickEditButton}>
+      독후감 수정
       <EditIcon size={size || 18} />
     </Button>
   ) : null;
@@ -39,6 +44,7 @@ export const DeleteButton = ({
 >) =>
   isShowDeleteButton ? (
     <Button onClick={onClickDeleteButton}>
+      독후감 삭제
       <DeleteIcon size={size || 18} />
     </Button>
   ) : null;

--- a/src/components/molecules/LikeButton/index.tsx
+++ b/src/components/molecules/LikeButton/index.tsx
@@ -14,8 +14,8 @@ const LikeButton = ({
   handleClick: handleClickLikeButton,
 }: LikeButtonProps) => (
   <Button css={iconButtonStyle} onClick={handleClickLikeButton}>
-    <HeartIcon size={size} active={active} />
     {active ? '좋아요 취소' : '좋아요'}
+    <HeartIcon size={size} active={active} />
   </Button>
 );
 

--- a/src/components/molecules/SearchButton/index.tsx
+++ b/src/components/molecules/SearchButton/index.tsx
@@ -9,8 +9,8 @@ const SearchButton = () => (
       ${iconButtonStyle};
     `}
   >
-    <SearchIcon size={25} />
     검색
+    <SearchIcon size={25} />
   </Button>
 );
 

--- a/src/components/organisms/DraftSavedListModal/DraftSavedItem.tsx
+++ b/src/components/organisms/DraftSavedListModal/DraftSavedItem.tsx
@@ -11,6 +11,7 @@ import {
   DraftSavedBookReview,
   DraftSavedBookReviewURLQuery,
 } from '@/types/features/bookReview';
+import { iconButtonStyle } from '@/styles/common';
 import * as s from './style';
 
 const DraftSavedItem = ({ id, bookname, createdAt }: DraftSavedBookReview) => {
@@ -46,7 +47,8 @@ const DraftSavedItem = ({ id, bookname, createdAt }: DraftSavedBookReview) => {
       </s.BookName>
       <s.DraftSavedItemBottom>
         <s.DraftSavedDate>{formatDateToKorean(createdAt)}</s.DraftSavedDate>
-        <Button onClick={handleClickDeleteButton}>
+        <Button onClick={handleClickDeleteButton} css={iconButtonStyle}>
+          임시저장 삭제
           <DeleteIcon size={17} />
         </Button>
       </s.DraftSavedItemBottom>

--- a/src/components/organisms/LikeCommentWidget/index.tsx
+++ b/src/components/organisms/LikeCommentWidget/index.tsx
@@ -47,8 +47,8 @@ const LikeCommentWidget = ({
           </s.WidgetItem>
           <s.WidgetItem>
             <Button css={s.buttonStyle} onClick={onClickCommentButton}>
-              <CommentIcon />
               댓글
+              <CommentIcon />
             </Button>
             <s.Count>{commentCount}</s.Count>
           </s.WidgetItem>

--- a/src/components/templates/BookReivew/style.ts
+++ b/src/components/templates/BookReivew/style.ts
@@ -18,6 +18,7 @@ export const Header = styled.header`
 export const HeaderTop = styled.div`
   margin-bottom: 10px;
   display: flex;
+  height: 13px;
 `;
 
 export const BookName = styled.h1`

--- a/src/styles/common.ts
+++ b/src/styles/common.ts
@@ -1,7 +1,7 @@
 import { css, Theme } from '@emotion/react';
 
 export const iconButtonStyle = css`
-  lineheight: 0;
+  line-height: 0;
   overflow: hidden;
   text-indent: -9999px;
 `;


### PR DESCRIPTION
### 작업 내용

> Chrome 외 환경에서 아이콘 버튼 내 텍스트가 보이지 않도록 해결

- 버튼 내 아이콘(svg)보다 텍스트가 먼저 오도록 변경
- Safari 브라우저 환경에서 테스트
