### PR TITLE
feat(promise) : Promise.settled 메서드를 Promise.all 메서드로 변경

### DIFF
--- a/server/constants/message.ts
+++ b/server/constants/message.ts
@@ -19,6 +19,7 @@ export const bookReviewError = {
   LIMIT_DRAFT_SAVE: '최대 10개의 독후감만 임시저장할 수 있습니다.',
   NOT_EXIST_BOOKREVIEW: '존재하지 않는 독후감입니다.',
   NOT_PUBLISHED_BOOKREVIEW: '발행되지 않은 독후감입니다.',
+  NOT_DELETED_BOOKREVIEW: '독후감이 정상적으로 삭제되지 않았습니다.',
 };
 
 export const commentError = {

--- a/server/features/bookReview/bookReview.model.ts
+++ b/server/features/bookReview/bookReview.model.ts
@@ -237,7 +237,7 @@ const bookReviewModel = {
       limit 12
     `;
 
-    const result = await query<FeedBookReview[]>(sql);
+    const result = await query<Omit<FeedBookReview, 'nick'>[]>(sql);
     return result;
   },
 
@@ -288,7 +288,7 @@ const bookReviewModel = {
       limit 12
     `;
 
-    const result = await query<FeedBookReview[]>(sql);
+    const result = await query<Omit<FeedBookReview, 'nick'>[]>(sql);
     return result;
   },
 

--- a/server/features/bookReview/bookReview.service.ts
+++ b/server/features/bookReview/bookReview.service.ts
@@ -66,29 +66,25 @@ const bookReviewService = {
       twoMonthDateInfo,
     );
 
-    const settledResult = await Promise.allSettled(
-      bookReviewList.map(
-        ({ user_id }): Promise<UserName | null> =>
-          userModel.getUserName({ id: user_id }),
-      ),
+    const promises = bookReviewList.map(
+      async ({
+        user_id,
+        ...bookReview
+      }): Promise<ExtendedBookReviewSummary> => {
+        const writer = await userModel.getUserName({ id: user_id });
+
+        return {
+          id: bookReview.id,
+          bookname: bookReview.bookname,
+          sejul: bookReview.sejul,
+          thumbnail: bookReview.thumbnail,
+          createdAt: bookReview.datecreated,
+          writer: writer || '',
+        };
+      },
     );
 
-    const writers = settledResult.map((_, i) => {
-      const result = settledResult[i];
-      if (result.status === 'fulfilled') {
-        return result.value || '';
-      }
-      return '';
-    });
-
-    const data = bookReviewList.map((bookReview, i) => ({
-      id: bookReview.id,
-      bookname: bookReview.bookname,
-      sejul: bookReview.sejul,
-      thumbnail: bookReview.thumbnail,
-      createdAt: bookReview.datecreated,
-      writer: writers[i],
-    }));
+    const data = await Promise.all(promises);
 
     return { error: false, data };
   },
@@ -98,29 +94,25 @@ const bookReviewService = {
   > => {
     const bookReviewList = await bookReviewModel.getLatestBookReviewList();
 
-    const settledResult = await Promise.allSettled(
-      bookReviewList.map(
-        ({ user_id }): Promise<UserName | null> =>
-          userModel.getUserName({ id: user_id }),
-      ),
+    const promises = bookReviewList.map(
+      async ({
+        user_id,
+        ...bookReview
+      }): Promise<ExtendedBookReviewSummary> => {
+        const writer = await userModel.getUserName({ id: user_id });
+
+        return {
+          id: bookReview.id,
+          bookname: bookReview.bookname,
+          sejul: bookReview.sejul,
+          thumbnail: bookReview.thumbnail,
+          createdAt: bookReview.datecreated,
+          writer: writer || '',
+        };
+      },
     );
 
-    const writers = settledResult.map((_, i) => {
-      const result = settledResult[i];
-      if (result.status === 'fulfilled') {
-        return result.value || '';
-      }
-      return '';
-    });
-
-    const data = bookReviewList.map((bookReview, i) => ({
-      id: bookReview.id,
-      bookname: bookReview.bookname,
-      sejul: bookReview.sejul,
-      thumbnail: bookReview.thumbnail,
-      createdAt: bookReview.datecreated,
-      writer: writers[i],
-    }));
+    const data = await Promise.all(promises);
 
     return { error: false, data };
   },
@@ -134,29 +126,25 @@ const bookReviewService = {
       user_id: userId,
     });
 
-    const settledResult = await Promise.allSettled(
-      bookReviewList.map(
-        ({ user_id }): Promise<UserName | null> =>
-          userModel.getUserName({ id: user_id }),
-      ),
+    const promises = bookReviewList.map(
+      async ({
+        user_id,
+        ...bookReview
+      }): Promise<ExtendedBookReviewSummary> => {
+        const writer = await userModel.getUserName({ id: user_id });
+
+        return {
+          id: bookReview.id,
+          bookname: bookReview.bookname,
+          sejul: bookReview.sejul,
+          thumbnail: bookReview.thumbnail,
+          createdAt: bookReview.datecreated,
+          writer: writer || '',
+        };
+      },
     );
 
-    const writers = settledResult.map((_, i) => {
-      const result = settledResult[i];
-      if (result.status === 'fulfilled') {
-        return result.value || '';
-      }
-      return '';
-    });
-
-    const data = bookReviewList.map((bookReview, i) => ({
-      id: bookReview.id,
-      bookname: bookReview.bookname,
-      sejul: bookReview.sejul,
-      thumbnail: bookReview.thumbnail,
-      createdAt: bookReview.datecreated,
-      writer: writers[i],
-    }));
+    const data = await Promise.all(promises);
 
     return { error: false, data };
   },
@@ -180,35 +168,26 @@ const bookReviewService = {
       maxId: bookReviewId,
     });
 
-    const settledResult = await Promise.allSettled(
-      bookReviewList.map(async ({ id }) => {
-        const likeCount = await likeModel.getLikeCount({
-          sejulbook_id: id,
-        });
-        const commentCount = await commentModel.getCommentCount({
-          sejulbook_id: id,
-        });
-        return [likeCount, commentCount];
-      }),
-    );
-
-    const data = bookReviewList.map(
-      ({ id, user_id, sejul, thumbnail, nick }, i) => {
-        const result = settledResult[i];
-        const [likeCount, commentCount] =
-          result.status === 'fulfilled' ? result.value : [0, 0];
+    const promises = await bookReviewList.map(
+      async ({ id, ...bookReview }): Promise<FeedFollowingBookReview> => {
+        const [likeCount, commentCount] = await Promise.all([
+          likeModel.getLikeCount({ sejulbook_id: id }),
+          commentModel.getCommentCount({ sejulbook_id: id }),
+        ]);
 
         return {
           id,
-          sejul,
-          thumbnail,
           likeCount,
           commentCount,
-          userId: user_id,
-          writer: nick || '',
+          sejul: bookReview.sejul,
+          thumbnail: bookReview.thumbnail,
+          userId: bookReview.user_id,
+          writer: bookReview.nick || '',
         };
       },
     );
+
+    const data = await Promise.all(promises);
 
     return { error: false, data };
   },
@@ -235,35 +214,26 @@ const bookReviewService = {
         maxId: bookReviewId,
       });
 
-    const settledResult = await Promise.allSettled(
-      bookReviewList.map(async ({ id }) => {
-        const likeCount = await likeModel.getLikeCount({
-          sejulbook_id: id,
-        });
-        const commentCount = await commentModel.getCommentCount({
-          sejulbook_id: id,
-        });
-        return [likeCount, commentCount];
-      }),
-    );
-
-    const data = bookReviewList.map(
-      ({ id, user_id, sejul, thumbnail, nick }, i) => {
-        const result = settledResult[i];
-        const [likeCount, commentCount] =
-          result.status === 'fulfilled' ? result.value : [0, 0];
+    const promises = await bookReviewList.map(
+      async ({ id, ...bookReview }): Promise<FeedFollowingBookReview> => {
+        const [likeCount, commentCount] = await Promise.all([
+          likeModel.getLikeCount({ sejulbook_id: id }),
+          commentModel.getCommentCount({ sejulbook_id: id }),
+        ]);
 
         return {
           id,
-          sejul,
-          thumbnail,
           likeCount,
           commentCount,
-          userId: user_id,
-          writer: nick || '',
+          sejul: bookReview.sejul,
+          thumbnail: bookReview.thumbnail,
+          userId: bookReview.user_id,
+          writer: bookReview.nick || '',
         };
       },
     );
+
+    const data = await Promise.all(promises);
 
     return { error: false, data };
   },
@@ -287,40 +257,31 @@ const bookReviewService = {
       maxId: bookReviewId,
     });
 
-    const settledResult = await Promise.allSettled(
-      bookReviewList.map(async ({ id, user_id }) => {
-        const writer = (await userModel.getUserName({ id: user_id })) || '';
-        const likeCount = await likeModel.getLikeCount({
-          sejulbook_id: id,
-        });
-        const commentCount = await commentModel.getCommentCount({
-          sejulbook_id: id,
-        });
-        return { writer, likeCount, commentCount };
-      }),
+    const promises = await bookReviewList.map(
+      async ({
+        id,
+        user_id,
+        ...bookReview
+      }): Promise<FeedFollowingBookReview> => {
+        const [writer, likeCount, commentCount] = await Promise.all([
+          userModel.getUserName({ id: user_id }),
+          likeModel.getLikeCount({ sejulbook_id: id }),
+          commentModel.getCommentCount({ sejulbook_id: id }),
+        ]);
+
+        return {
+          id,
+          likeCount,
+          commentCount,
+          userId: user_id,
+          writer: writer || '',
+          sejul: bookReview.sejul,
+          thumbnail: bookReview.thumbnail,
+        };
+      },
     );
 
-    const data = bookReviewList.map(({ id, user_id, sejul, thumbnail }, i) => {
-      const result = settledResult[i];
-      const { writer, likeCount, commentCount } =
-        result.status === 'fulfilled'
-          ? result.value
-          : {
-              writer: '',
-              likeCount: 0,
-              commentCount: 0,
-            };
-
-      return {
-        id,
-        sejul,
-        thumbnail,
-        writer,
-        likeCount,
-        commentCount,
-        userId: user_id,
-      };
-    });
+    const data = await Promise.all(promises);
 
     return { error: false, data };
   },
@@ -345,40 +306,31 @@ const bookReviewService = {
         maxId: bookReviewId,
       });
 
-    const settledResult = await Promise.allSettled(
-      bookReviewList.map(async ({ id, user_id }) => {
-        const writer = (await userModel.getUserName({ id: user_id })) || '';
-        const likeCount = await likeModel.getLikeCount({
-          sejulbook_id: id,
-        });
-        const commentCount = await commentModel.getCommentCount({
-          sejulbook_id: id,
-        });
-        return { writer, likeCount, commentCount };
-      }),
+    const promises = await bookReviewList.map(
+      async ({
+        id,
+        user_id,
+        ...bookReview
+      }): Promise<FeedFollowingBookReview> => {
+        const [writer, likeCount, commentCount] = await Promise.all([
+          userModel.getUserName({ id: user_id }),
+          likeModel.getLikeCount({ sejulbook_id: id }),
+          commentModel.getCommentCount({ sejulbook_id: id }),
+        ]);
+
+        return {
+          id,
+          likeCount,
+          commentCount,
+          userId: user_id,
+          writer: writer || '',
+          sejul: bookReview.sejul,
+          thumbnail: bookReview.thumbnail,
+        };
+      },
     );
 
-    const data = bookReviewList.map(({ id, user_id, sejul, thumbnail }, i) => {
-      const result = settledResult[i];
-      const { writer, likeCount, commentCount } =
-        result.status === 'fulfilled'
-          ? result.value
-          : {
-              writer: '',
-              likeCount: 0,
-              commentCount: 0,
-            };
-
-      return {
-        id,
-        sejul,
-        thumbnail,
-        writer,
-        likeCount,
-        commentCount,
-        userId: user_id,
-      };
-    });
+    const data = await Promise.all(promises);
 
     return { error: false, data };
   },
@@ -392,33 +344,26 @@ const bookReviewService = {
       user_id: userId,
     });
 
-    const settledResult = await Promise.allSettled(
-      bookReviewList.map(async ({ id }) => {
-        const likeCount = await likeModel.getLikeCount({
-          sejulbook_id: id,
-        });
-        const commentCount = await commentModel.getCommentCount({
-          sejulbook_id: id,
-        });
-        return [likeCount, commentCount];
-      }),
-    );
-
-    const data = bookReviewList.map(
-      ({ id, datecreated, ...bookReviewSummary }, i) => {
-        const result = settledResult[i];
-        const [likeCount, commentCount] =
-          result.status === 'fulfilled' ? result.value : [0, 0];
+    const promises = bookReviewList.map(
+      async ({ id, ...bookReview }): Promise<BookReviewSummary> => {
+        const [likeCount, commentCount] = await Promise.all([
+          likeModel.getLikeCount({ sejulbook_id: id }),
+          commentModel.getCommentCount({ sejulbook_id: id }),
+        ]);
 
         return {
           id,
           likeCount,
           commentCount,
-          createdAt: datecreated,
-          ...bookReviewSummary,
+          bookname: bookReview.bookname,
+          sejul: bookReview.sejul,
+          thumbnail: bookReview.thumbnail,
+          createdAt: bookReview.datecreated,
         };
       },
     );
+
+    const data = await Promise.all(promises);
 
     return { error: false, data };
   },
@@ -457,24 +402,18 @@ const bookReviewService = {
 
     const bookReview = formatEntityToDTO(bookReviewData);
 
-    const settledResult = await Promise.allSettled([
+    const [userName, { category }] = await Promise.all([
       userModel.getUserName({ id: bookReview.userId }),
       categoryModel.getCategory({ id: bookReview.categoryId }),
     ]);
 
-    if (settledResult[0].status !== 'fulfilled' || !settledResult[0].value) {
+    if (!userName) {
       return {
         error: true,
         code: 400,
         message: userError.USER_NOT_FOUND,
       };
     }
-
-    const userName = settledResult[0].value;
-    const category =
-      settledResult[1].status === 'fulfilled'
-        ? settledResult[1].value.category
-        : '';
 
     const data: PublishedBookReview = {
       ...bookReview,
@@ -577,14 +516,22 @@ const bookReviewService = {
   deletedBookReview: async ({
     id,
   }: Pick<BookReviewDTO, 'id'>): Promise<HttpResponse<undefined>> => {
-    await Promise.allSettled([
-      commentModel.deleteComments({ sejulbook_id: id }),
-      tagModel.deleteTags({ sejulbook_id: id }),
-      likeModel.deleteAllLikes({ sejulbook_id: id }),
-      bookReviewModel.deleteBookReview({ id }),
-    ]);
+    try {
+      await Promise.all([
+        commentModel.deleteComments({ sejulbook_id: id }),
+        tagModel.deleteTags({ sejulbook_id: id }),
+        likeModel.deleteAllLikes({ sejulbook_id: id }),
+        bookReviewModel.deleteBookReview({ id }),
+      ]).catch;
 
-    return { error: false, data: undefined };
+      return { error: false, data: undefined };
+    } catch (error) {
+      return {
+        error: true,
+        code: 500,
+        message: bookReviewError.NOT_DELETED_BOOKREVIEW,
+      };
+    }
   },
 };
 

--- a/server/features/follow/follow.service.ts
+++ b/server/features/follow/follow.service.ts
@@ -41,7 +41,7 @@ const followService = {
     targetUserId: UserId;
     myUserId?: UserId;
   }): Promise<HttpResponse<FollowInfo>> => {
-    const result = await Promise.allSettled([
+    const [followerCount, followingCount, isFollow] = await Promise.all([
       followModel.getFollowerCount({
         following_id: targetUserId,
       }),
@@ -55,14 +55,6 @@ const followService = {
           })
         : false,
     ]);
-
-    const followerCount =
-      result[0].status === 'fulfilled' ? result[0].value : 0;
-
-    const followingCount =
-      result[1].status === 'fulfilled' ? result[1].value : 0;
-
-    const isFollow = result[2].status === 'fulfilled' ? result[2].value : false;
 
     return {
       error: false,

--- a/server/features/like/like.service.ts
+++ b/server/features/like/like.service.ts
@@ -16,7 +16,7 @@ const likeService = {
   }: Omit<LikeDTO, 'likerId'> & { likerId?: UserId }): Promise<
     HttpSuccess<LikeStatus> | HttpFailed
   > => {
-    const result = await Promise.allSettled([
+    const [myLike, likeCount] = await Promise.all([
       likerId
         ? likeModel.getLike({
             sejulbook_id: bookReviewId,
@@ -28,8 +28,6 @@ const likeService = {
       }),
     ]);
 
-    const myLike = result[0].status === 'fulfilled' ? result[0].value : [];
-    const likeCount = result[1].status === 'fulfilled' ? result[1].value : 0;
     const isLike = !!myLike.length;
 
     return { error: false, data: { isLike, likeCount } };

--- a/server/features/tag/tag.service.ts
+++ b/server/features/tag/tag.service.ts
@@ -23,8 +23,8 @@ const tagService = {
   }: { tags: Tag[] } & Pick<TagDTO, 'bookReviewId'>): Promise<
     HttpResponse<undefined>
   > => {
-    await Promise.allSettled(
-      tags.map((tag) =>
+    await Promise.all(
+      tags.map(async (tag) =>
         tagModel.createTags({ tag, sejulbook_id: bookReviewId }),
       ),
     );

--- a/server/features/user/user.service.ts
+++ b/server/features/user/user.service.ts
@@ -178,21 +178,19 @@ const userService = {
           maxFollowId: followId,
         });
 
-    const settledResult = await Promise.allSettled(
-      followUserList.map(({ id: otherUserId }) =>
-        myUserId
+    const promises = followUserList.map(
+      async ({
+        id: otherUserId,
+        nick,
+        introduce,
+        follow_id,
+      }): Promise<User & { followId: FollowId; isFollow: boolean }> => {
+        const isFollow = await (myUserId
           ? followModel.getIsFollow({
               following_id: otherUserId,
               follower_id: myUserId,
             })
-          : false,
-      ),
-    );
-
-    const data = followUserList.map(
-      ({ id: otherUserId, nick, introduce, follow_id }, i) => {
-        const result = settledResult[i];
-        const isFollow = result.status === 'fulfilled' ? result.value : false;
+          : false);
 
         return {
           id: otherUserId,
@@ -203,6 +201,8 @@ const userService = {
         };
       },
     );
+
+    const data = await Promise.all(promises);
 
     return {
       error: false,

--- a/src/services/prefetchQuery.ts
+++ b/src/services/prefetchQuery.ts
@@ -7,7 +7,7 @@ const prefetchQuery = async (
 ) => {
   const queryClient = new QueryClient();
 
-  await Promise.allSettled([
+  await Promise.all([
     ...queries.map(({ queryKey, queryFn }) =>
       queryClient.prefetchQuery(queryKey, queryFn),
     ),


### PR DESCRIPTION
### 작업 내용

> 빈번히 사용된 `Promise.settled` 메서드를 `Promise.all` 메서드로 변경

- bookreview service 내 `Promise.all` 메서드 적용
- tag service 내 `Promise.all` 메서드 적용
- user service 내 `Promise.all` 메서드 적용
- like service 내 `Promise.all` 메서드 적용
- follow service 내 `Promise.all` 메서드 적용
- client `prefetchQuery` `Promise.all` 메서드 적용
